### PR TITLE
hotfix/ENG21-494-Date-picker-Mobile-button-padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtw-accessible-react-datepicker",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "An accessible datepicker with all the keyboard bindings, compatible with React",
   "keywords": [
     "datepicker",

--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -7,6 +7,10 @@ import Day from './Day';
 import { getDownDay, getLeftDay, getRightDay, getUpDay } from './utils/funcs/getNextKeyboardDays';
 import { datepickerCtx } from './utils/ctx';
 
+//35 is the number of date spaces that has 5 rows and 7 columns (days of the week)
+//After that a new row is needed to store the reminding dates
+const numberSpacesCalendar = 35;
+
 const Keys = {
     Up: 'ArrowUp',
     Down: 'ArrowDown',
@@ -16,12 +20,14 @@ const Keys = {
 
 interface DaysProps {
     date: IDay;
+    isMultiple?: boolean;
 }
 
-const Grid = styled.div<{ days?: boolean }>`
+const Grid = styled.div<{ days?: boolean, numberDays?: number}>`
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    ${({ days }) => (days ? `grid-template-rows: repeat(6, 1fr);` : '')}
+    ${({ days, numberDays }) => ((days && numberDays) ?  
+        `grid-template-rows: repeat(${(numberDays > numberSpacesCalendar ) ? '6' : '5'}, 1fr);` : '')}
     place-items: center;
 `;
 
@@ -34,7 +40,6 @@ const Calendar: React.FC<DaysProps> = ({ date }) => {
     const { days, months, styles, setFocusable, onNext, onPrevious } = useContext(datepickerCtx);
 
     const { month, year } = date;
-
     const handleKey = (e: React.KeyboardEvent<HTMLButtonElement>, day: number) => {
         if (!Object.values(Keys).includes(e.code)) return;
         e.preventDefault();
@@ -80,7 +85,7 @@ const Calendar: React.FC<DaysProps> = ({ date }) => {
                     </WeekDay>
                 ))}
             </Grid>
-            <Grid days>
+            <Grid days numberDays={calendar.calendar.length}>
                 {calendar.calendar.map((day, i) => (
                     <Day
                         day={{ day, month, year }}

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -219,7 +219,7 @@ const DatePicker: React.FC<DatePickerProps> = ({
                     <Header months={currentMonths} />
                     <Flex justifyContent="center" columnGap="40px">
                         <Calendar date={date} />
-                        {isMultiple && <Calendar date={secondDate} />}
+                        {isMultiple && <Calendar date={secondDate}/>}
                     </Flex>
                     <Flex justifyContent="space-between">
                         {showClose && <Close onClick={() => handleToggle()}>{buttonsLabels.closeLabel || 'Close'}</Close>}

--- a/src/utils/funcs/generateCalendar.ts
+++ b/src/utils/funcs/generateCalendar.ts
@@ -21,7 +21,7 @@ export const generateMonthCalendar = (date: Day): Calendar => {
         days.push(i);
     }
 
-    // Add missing days at the beggining of the calendar
+    // Add missing days at the beginning of the calendar
     let missingSpots = (8 - ((day - weekDay) % 7)) % 7;
 
     for (let i = 0; i < missingSpots; i++) {


### PR DESCRIPTION
Jira task addressed: [ENG21-494](https://wheeltheworld.atlassian.net/browse/ENG21-494?atlOrigin=eyJpIjoiOWFjZGE0Y2Q5ZDcxNGFkMTk2YWE3YjA3YzY5OTljZjciLCJwIjoiaiJ9)

In this PR the padding that was below the calendar was due to rendering 6 rows instead of 5 depending on the month so now its 5 if the month has less than 35 spaces or 6 if a new row is needed to store the reminding dates

https://user-images.githubusercontent.com/24198681/150793986-07a9c353-01bb-4446-94a1-1a6650491706.mov


