### PR TITLE
fix: double dates staying on single calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,5 @@
     "@emotion/styled": "^11.3.0",
     "focus-trap-react": "^8.5.0",
     "wtw-icons": "^1.17.0"
-  },
-  "engines": {
-    "node": "14",
-    "yarn": ">=1.5"
   }
 }

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -50,11 +50,11 @@ const Container = styled.div<{
     ${({ custom, fullScreen }) => (custom ? (typeof custom === 'string' ? custom : custom(fullScreen)) : '')}
 `;
 
-const Flex = styled.div<{justifyContent?: string; columnGap?: string }>`
-    display: flex; 
+const Flex = styled.div<{ justifyContent?: string; columnGap?: string }>`
+    display: flex;
     justify-content: ${({ justifyContent }) => justifyContent};
-    column-gap: ${({ columnGap }) => columnGap};;
-`
+    column-gap: ${({ columnGap }) => columnGap}; ;
+`;
 
 const Close = styled.button`
     text-decoration: underline;
@@ -74,7 +74,7 @@ const Clear = styled.button`
     align-self: flex-end;
     font-size: 16px;
     font-weight: bold;
-    color: #007A87;
+    color: #007a87;
 `;
 
 const Save = styled.button`
@@ -102,7 +102,7 @@ export interface DatePickerProps {
     showClose?: boolean;
     showSave?: boolean;
     showCleanDates?: boolean;
-    buttonsLabels?: { closeLabel?: string; saveLabel?: string; clearLabel?: string }
+    buttonsLabels?: { closeLabel?: string; saveLabel?: string; clearLabel?: string };
 }
 
 const DatePicker: React.FC<DatePickerProps> = ({
@@ -119,7 +119,7 @@ const DatePicker: React.FC<DatePickerProps> = ({
     multipleSelect = true,
     showSave = true,
     showCleanDates = true,
-    buttonsLabels = {closeLabel: 'Close', saveLabel: 'Save', clearLabel: 'Clear dates'}
+    buttonsLabels = { closeLabel: 'Close', saveLabel: 'Save', clearLabel: 'Clear dates' },
 }) => {
     const window = useWindowSize();
 
@@ -181,12 +181,14 @@ const DatePicker: React.FC<DatePickerProps> = ({
         handleToggle();
     });
 
-    const actualMaxDate = useMemo(() => (maxDate ? (maxDate === 'today' ? generateDay(new Date()) : maxDate) : null), [
-        maxDate,
-    ]);
-    const actualMinDate = useMemo(() => (minDate ? (minDate === 'today' ? generateDay(new Date()) : minDate) : null), [
-        minDate,
-    ]);
+    const actualMaxDate = useMemo(
+        () => (maxDate ? (maxDate === 'today' ? generateDay(new Date()) : maxDate) : null),
+        [maxDate],
+    );
+    const actualMinDate = useMemo(
+        () => (minDate ? (minDate === 'today' ? generateDay(new Date()) : minDate) : null),
+        [minDate],
+    );
 
     return isOpen ? (
         <datepickerCtx.Provider
@@ -219,12 +221,22 @@ const DatePicker: React.FC<DatePickerProps> = ({
                     <Header months={currentMonths} />
                     <Flex justifyContent="center" columnGap="40px">
                         <Calendar date={date} />
-                        {isMultiple && <Calendar date={secondDate}/>}
+                        {isMultiple && <Calendar date={secondDate} />}
                     </Flex>
                     <Flex justifyContent="space-between">
-                        {showClose && <Close onClick={() => handleToggle()}>{buttonsLabels.closeLabel || 'Close'}</Close>}
-                        {showCleanDates && <Clear type="button" onClick={() => clearDates()}>{buttonsLabels.clearLabel || 'Clear dates'}</Clear>}
-                        {showSave && <Save type="button" onClick={() => handleToggle()}>{buttonsLabels.saveLabel || 'Save'}</Save>}
+                        {showClose && (
+                            <Close onClick={() => handleToggle()}>{buttonsLabels.closeLabel || 'Close'}</Close>
+                        )}
+                        {showCleanDates && (
+                            <Clear type="button" onClick={() => clearDates()}>
+                                {buttonsLabels.clearLabel || 'Clear dates'}
+                            </Clear>
+                        )}
+                        {showSave && (
+                            <Save type="button" onClick={() => handleToggle()}>
+                                {buttonsLabels.saveLabel || 'Save'}
+                            </Save>
+                        )}
                     </Flex>
                 </Container>
             </FocusTrap>

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -12,6 +12,7 @@ export default {
 
 const Template: Story<DatePickerProps> = (args) => {
     const [open, toggle] = useToggle(true);
+    const [multiple, toggleMultiple] = useToggle(true);
     const [date, setDate] = useState<SelectedDates>([null, null]);
     return (
         <>
@@ -25,8 +26,16 @@ const Template: Story<DatePickerProps> = (args) => {
           }`
                     : 'Datepicker'}
             </button>
+            <button onClick={() => toggleMultiple()}>toggle multiple</button>
 
-            <Datepicker {...args} isOpen={open} handleToggle={toggle} onChange={setDate} value={date} />
+            <Datepicker
+                {...args}
+                isOpen={open}
+                handleToggle={toggle}
+                onChange={setDate}
+                value={date}
+                multipleSelect={multiple}
+            />
         </>
     );
 };

--- a/src/utils/hooks/useDateSelector.ts
+++ b/src/utils/hooks/useDateSelector.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Day } from '../../types/Day';
 import { Tuple } from '../../types/Tuple';
 import { dayIsSooner } from '../funcs/dayIsSooner';
@@ -30,6 +30,12 @@ export const useDateSelector = (initial?: Tuple<Day | null, 1 | 2>, isMultiple =
             setSelected([day]);
         }
     };
+
+    useEffect(() => {
+        if (!isMultiple) {
+            setSelected([selected[0]]);
+        }
+    }, [selected, isMultiple]);
 
     /**
      * Will clear the dates when called


### PR DESCRIPTION
- Fix double date staying when changing a double calendar to simple


There was an effect missing that would check if the kind of the calendar changed to set only one date instead of two