### PR TITLE
WEBST-251 Change disabled styles and reset dates when a third one is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtw-accessible-react-datepicker",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "An accessible datepicker with all the keyboard bindings, compatible with React",
   "keywords": [
     "datepicker",

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -28,7 +28,7 @@ const Circle = styled.div<{
         disabled
             ? `
       color: ${styles.disabled};
-      text-decoration: line-through;
+      font-style: italic;
 
       `
             : `&:hover {

--- a/src/__test__/utils/hooks/useDateSelector.test.ts
+++ b/src/__test__/utils/hooks/useDateSelector.test.ts
@@ -99,7 +99,7 @@ describe('useToggle()', () => {
         act(() => {
             result.current.addDate(third);
         });
-        expect(result.current.selected).toEqual([first, third]);
+        expect(result.current.selected).toEqual([third, null]);
     });
 
     it('should remove the second selected date if the date added is the same than the second', () => {
@@ -150,7 +150,7 @@ describe('useToggle()', () => {
         expect(result.current.selected).toEqual([null, null]);
     });
 
-    it('should change the first selected date if the date added is sooner than the first date', () => {
+    it('should replace the first date with a third date and remove the second one', () => {
         const { result } = renderHook(() => useDateSelector());
         const first: Day = {
             day: 12,
@@ -176,7 +176,7 @@ describe('useToggle()', () => {
         act(() => {
             result.current.addDate(third);
         });
-        expect(result.current.selected).toEqual([third, second]);
+        expect(result.current.selected).toEqual([third, null]);
     });
 
     it('should change the first selected date if the date added is sooner than the first date', () => {

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -1,42 +1,41 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import Datepicker, { DatePickerProps } from '../DatePicker';
-import { useToggle } from '../utils/hooks/useToggle';
-import { SelectedDates } from '../types/SelectedDates';
 import { generateDay } from '../utils/funcs/generateDay';
 
 export default {
     title: 'Atoms/DatePicker',
     component: Datepicker,
+    argTypes: {
+        isOpen: {
+            control: {
+                type: 'boolean'
+            },
+            defaultValue: true
+        },
+        multipleSelect: {
+            control: {
+                type: 'boolean'
+            }
+        },
+        value: {
+            control: { type: 'object' },
+            defaultValue: []
+        },
+        minDate: {
+            control: { type: 'object' }
+        },
+        maxDate: {
+            control: { type: 'object' }
+        },
+    }
 } as Meta;
 
 const Template: Story<DatePickerProps> = (args) => {
-    const [open, toggle] = useToggle(true);
-    const [multiple, toggleMultiple] = useToggle(true);
-    const [date, setDate] = useState<SelectedDates>([null, null]);
     return (
-        <>
-            <button onClick={() => toggle()}>
-                {date[0]
-                    ? `Selected from ${date[0].day}/${date[0].month}/${date[0].year}
-          ${
-              date[1] &&
-              `to ${date[1].day}/${date[1].month}/
-          ${date[1].year}`
-          }`
-                    : 'Datepicker'}
-            </button>
-            <button onClick={() => toggleMultiple()}>toggle multiple</button>
-
-            <Datepicker
+        <Datepicker
                 {...args}
-                isOpen={open}
-                handleToggle={toggle}
-                onChange={setDate}
-                value={date}
-                multipleSelect={multiple}
             />
-        </>
     );
 };
 

--- a/src/utils/hooks/useDateSelector.ts
+++ b/src/utils/hooks/useDateSelector.ts
@@ -13,8 +13,15 @@ export const useDateSelector = (initial?: Tuple<Day | null, 1 | 2>, isMultiple =
     const addDate = (day: Day) => {
         if (isMultiple) {
             if (selected[0] && selected[1]) {
+                if(JSON.stringify(day) === JSON.stringify(selected[1])) {
+                    return setSelected([selected[0], null]);
+                }
+                if(JSON.stringify(day) === JSON.stringify(selected[0])) {
+                    return setSelected([null, null]);
+                }
                 return setSelected([day, null]);
             }
+
             if (!selected[0]) return setSelected([day, null]);
 
             if (JSON.stringify(day) === JSON.stringify(selected[0])) return setSelected([null, null]);

--- a/src/utils/hooks/useDateSelector.ts
+++ b/src/utils/hooks/useDateSelector.ts
@@ -12,6 +12,9 @@ export const useDateSelector = (initial?: Tuple<Day | null, 1 | 2>, isMultiple =
 
     const addDate = (day: Day) => {
         if (isMultiple) {
+            if (selected[0] && selected[1]) {
+                return setSelected([day, null]);
+            }
             if (!selected[0]) return setSelected([day, null]);
 
             if (JSON.stringify(day) === JSON.stringify(selected[0])) return setSelected([null, null]);


### PR DESCRIPTION
This PR does:
- Change disabled styles to italic instead of strikethrough
- Now when we have two selected dates, a third one will reset the selection using the third one as the first.
- Also changes the story of the component to leave controls to storybook instead of the in-component controls.

NOTE: The in-component controls were preventing to the component to behave properly along with storybook controls

https://user-images.githubusercontent.com/98823824/171063445-94c71845-53c6-4ad2-8c97-772c26690a08.mov


