### PR TITLE
Hotfix/timezone side effect fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtw-accessible-react-datepicker",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "An accessible datepicker with all the keyboard bindings, compatible with React",
   "keywords": [
     "datepicker",

--- a/src/__test__/utils/funcs/generateDay.test.ts
+++ b/src/__test__/utils/funcs/generateDay.test.ts
@@ -8,4 +8,12 @@ describe('generateDay()', () => {
             year: 2021,
         });
     });
+    it('should return the day without any timezone side effects', () => {
+        const dateInStringForm = new Date('2022-08-05T00:00:00.000Z');
+        expect(generateDay(dateInStringForm)).toEqual({
+            day: 5,
+            month: 8,
+            year: 2022,
+        });
+    });
 });

--- a/src/utils/funcs/generateDay.ts
+++ b/src/utils/funcs/generateDay.ts
@@ -4,7 +4,7 @@ import { Day } from '../../types/Day';
  * Gets a javascript Date and returns a datepicker Day
  */
 export const generateDay = (date: Date): Day => ({
-    day: date.getDate(),
-    month: date.getMonth() + 1,
-    year: date.getFullYear(),
+    day: date.getUTCDate(),
+    month: date.getUTCMonth() + 1,
+    year: date.getUTCFullYear(),
 });


### PR DESCRIPTION
In this PR the timezone side effect was fixed using a UTC function, feat @mcadizwtw 

When I was recording a video showing the feature in this [jira card](https://wheeltheworld.atlassian.net/browse/WEBST-315?atlOrigin=eyJpIjoiMzA1OGYxNGViNzE0NGZlMzgwZjI1YWY5NTFiNzVhYWUiLCJwIjoiaiJ9) I encountered this bug (one less day due to UTM -4) and this was setting false information in the booking cards on the trips page that were using the generateDay function:

https://user-images.githubusercontent.com/24198681/173921773-f89c4c3e-f7e1-4265-a743-746e36732ef9.mov


