### PR TITLE
`fix/PTS-722`: timezone bug in generate date

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wtw-accessible-react-datepicker",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "An accessible datepicker with all the keyboard bindings, compatible with React",
   "keywords": [
     "datepicker",

--- a/src/__test__/utils/funcs/differenceBetweenDays.test.ts
+++ b/src/__test__/utils/funcs/differenceBetweenDays.test.ts
@@ -1,0 +1,57 @@
+import { Day } from '../../../types/Day';
+import { differenceBetweenDays } from '../../../utils/funcs/differenceBetweenDays';
+
+describe('differenceBetweenDays', () => {
+    it('should return 0 when some parameter is missing', () => {
+        const date: Day = { year: 2020, month: 1, day: 15 };
+
+        let result = differenceBetweenDays(date, null);
+        expect(result).toBe(0);
+
+        result = differenceBetweenDays(null, date);
+        expect(result).toBe(0);
+        result = differenceBetweenDays(null, null);
+        expect(result).toBe(0);
+    });
+    it('should work correctly when month is March', () => {
+        const year = 2022;
+        const month = 3;
+        const initDay = 12;
+        const diffDay = 3;
+        const startDate: Day = { year, month, day: initDay };
+        const endDate: Day = { year, month, day: initDay + diffDay };
+
+        const result = differenceBetweenDays(startDate, endDate);
+
+        expect(result).toBe(diffDay);
+    });
+    it('should work correctly when startDay is older than endDate', () => {
+        const year = 2022;
+        const month = 3;
+        const initDay = 15;
+        const diffDay = 3;
+        const startDate: Day = { year, month, day: initDay };
+        const endDate: Day = { year, month, day: initDay - diffDay };
+
+        const result = differenceBetweenDays(startDate, endDate);
+
+        expect(result).toBe(diffDay);
+    });
+    it('should work correctly when year is leap year', () => {
+        const year = 2020;
+        const startDate: Day = { year, month: 2, day: 27 };
+        const endDate: Day = { year, month: 3, day: 2 };
+
+        const result = differenceBetweenDays(startDate, endDate);
+
+        expect(result).toBe(4);
+    });
+    it('should work correctly when years differ', () => {
+        const startDate: Day = { year: 2020, month: 12, day: 27 };
+        const endDate: Day = { year: 2021, month: 1, day: 2 };
+
+        const result = differenceBetweenDays(startDate, endDate);
+
+        expect(result).toBe(6);
+    });
+});

--- a/src/__test__/utils/funcs/generateDate.test.ts
+++ b/src/__test__/utils/funcs/generateDate.test.ts
@@ -1,0 +1,23 @@
+import { Day } from '../../../types/Day';
+import { generateDate } from '../../../utils/funcs/generateDate';
+
+describe('generateDate', () => {
+    const day: Day = { year: 2020, month: 2, day: 2 };
+    it('should return JS date', () => {
+        const result = generateDate(day);
+
+        expect(result).toBeInstanceOf(Date);
+    });
+    it('should return correct month', () => {
+        const month = 2;
+        const result = generateDate({ ...day, month });
+
+        expect(result.getUTCMonth()).toBe(month - 1);
+    });
+
+    it.only('should set hour to 00', () => {
+        const result = generateDate(day);
+
+        expect(result.getUTCHours()).toBe(0);
+    });
+});

--- a/src/__test__/utils/funcs/generateDate.test.ts
+++ b/src/__test__/utils/funcs/generateDate.test.ts
@@ -15,7 +15,7 @@ describe('generateDate', () => {
         expect(result.getUTCMonth()).toBe(month - 1);
     });
 
-    it.only('should set hour to 00', () => {
+    it('should set hour to 00', () => {
         const result = generateDate(day);
 
         expect(result.getUTCHours()).toBe(0);

--- a/src/__test__/utils/funcs/generateDay.test.ts
+++ b/src/__test__/utils/funcs/generateDay.test.ts
@@ -1,12 +1,28 @@
+import { Day } from '../../../types/Day';
 import { generateDay } from '../../../utils/funcs/generateDay';
 
-describe('generateDay()', () => {
-    it('should return the correct day', () => {
-        expect(generateDay(new Date(2021, 3, 13))).toEqual({
-            day: 13,
-            month: 4,
-            year: 2021,
-        });
+describe('generateDay', () => {
+    const year = 2021;
+    const month = 11;
+    const day = 31;
+    const JSDate = new Date(year, month, day);
+
+    let result: Day;
+
+    beforeEach(() => {
+        result = generateDay(JSDate);
     });
 
+    it('should return a Day object', () => {
+        expect(result).toMatchObject(
+            expect.objectContaining({
+                year: expect.any(Number),
+                month: expect.any(Number),
+                day: expect.any(Number),
+            }),
+        );
+    });
+    it('should return the correct day', () => {
+        expect(result).toEqual({ day, month: month + 1, year });
+    });
 });

--- a/src/types/Day.ts
+++ b/src/types/Day.ts
@@ -1,5 +1,9 @@
+/** Object that represents a Day of the year.
+ * It's `month` property is evaluated as 1-based indexed.
+ * JS Date's `month` is 0-based indexed
+ */
 export interface Day {
+    year: number;
     month: number;
     day: number;
-    year: number;
 }

--- a/src/utils/funcs/differenceBetweenDays.ts
+++ b/src/utils/funcs/differenceBetweenDays.ts
@@ -1,11 +1,14 @@
 import { Day } from '../../types/Day';
+import { fromMiliSecondsToDay } from './fromMiliSecondsToDay';
 import { generateDate } from './generateDate';
 
 /**
  * Returns the difference between two datepicker Days
  */
-export const differenceBetweenDays = (day1: Day | null, day2: Day | null) => {
+export const differenceBetweenDays = (day1: Day | null, day2: Day | null): number => {
     if (!day1 || !day2) return 0;
+
     const diffTime = Math.abs(generateDate(day1).valueOf() - generateDate(day2).valueOf());
-    return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+    return fromMiliSecondsToDay(diffTime);
 };

--- a/src/utils/funcs/fromMiliSecondsToDay.ts
+++ b/src/utils/funcs/fromMiliSecondsToDay.ts
@@ -1,0 +1,4 @@
+/** Converts from milliseconds to days */
+export function fromMiliSecondsToDay(milliseconds: number): number {
+    return Math.floor(milliseconds / (1000 * 60 * 60 * 24));
+}

--- a/src/utils/funcs/generateCalendar.ts
+++ b/src/utils/funcs/generateCalendar.ts
@@ -13,7 +13,7 @@ interface Calendar {
  */
 export const generateMonthCalendar = (date: Day): Calendar => {
     const { year, month, day } = date;
-    const weekDay = generateDate(date).getDay();
+    const weekDay = generateDate(date).getUTCDay();
     const days: number[] = [];
 
     // Add all the days of the month

--- a/src/utils/funcs/generateDate.ts
+++ b/src/utils/funcs/generateDate.ts
@@ -1,6 +1,8 @@
 import { Day } from '../../types/Day';
 
 /**
- *  gets a datepicker Day and returns a javascript Date
+ *  Transform a DatePicker's `Day` into a JS's `Date`
  */
-export const generateDate = (day: Day) => new Date(day.year, day.month - 1, day.day);
+export const generateDate = ({ year, month, day }: Day): Date =>
+    // Month in `Day` type are 1-based indexed
+    new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));

--- a/src/utils/funcs/generateDate.ts
+++ b/src/utils/funcs/generateDate.ts
@@ -1,7 +1,11 @@
 import { Day } from '../../types/Day';
 
 /**
- *  Transform a DatePicker's `Day` into a JS's `Date`
+ * Transform a DatePicker's `Day` into a JS's `Date`.
+ *
+ * UTC time was used to ensure resulting JS's `Date` represent the beginning of the
+ * day. Please use UTC-equivalent JSDate's methods on the resulting `Date`.
+ * Otherwise timezone related bugs may appear.
  */
 export const generateDate = ({ year, month, day }: Day): Date =>
     // Month in `Day` type are 1-based indexed

--- a/src/utils/funcs/generateDay.ts
+++ b/src/utils/funcs/generateDay.ts
@@ -1,10 +1,10 @@
 import { Day } from '../../types/Day';
 
 /**
- * Gets a javascript Date and returns a datepicker Day
+ * Transform a JS's `Date` into a DatePicker's `Day`
  */
 export const generateDay = (date: Date): Day => ({
-    day: date.getDate(),
-    month: date.getMonth() + 1,
-    year: date.getFullYear(),
+    day: date.getUTCDate(),
+    month: date.getUTCMonth() + 1,
+    year: date.getUTCFullYear(),
 });


### PR DESCRIPTION
This PR makes `generateDate` use `Date.UTC`. There was some time-zone related date drifting because `generateDate` used to capture host's timezone, to generated Date had an `hour` different from `00`.

NOTE: `generateMonthCalendar`'s test suite failed because it seems that now callers of `generateDate` need to use UTC methods. This may be a breaking change. Currently [wtw-website](https://github.com/wheeltheworld/wtw-website) does not use this util function but this side effect may bring some bugs