### PR TITLE
`Fix/PTS-1011` Fully color the day container on select 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wtw-accessible-react-datepicker",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "An accessible datepicker with all the keyboard bindings, compatible with React",
     "keywords": [
         "datepicker",

--- a/src/Day.tsx
+++ b/src/Day.tsx
@@ -58,8 +58,9 @@ const DayContainer = styled.div<{
             ? ''
             : selected
             ? `
-    background: linear-gradient(${right ? '' : '-'}90deg, ${color} 0%, ${color} 50%, white 50%, white 100%);
-`
+    background: linear-gradient(${right ? '' : '-'}90deg, ${color} 0%, ${color} ${
+                  right ? '25' : '75'
+              }%, white 50%, white 100%);`
             : ''}
 
     ${({ between, color, disabled }) =>
@@ -77,6 +78,7 @@ const Clickable = styled.button<{ selected: boolean; color: string }>`
     background: none;
     border: none;
     height: 100%;
+    width: 100%;
     padding: 3.5px 0;
     outline: none;
     cursor: pointer;


### PR DESCRIPTION
In order to fix this problem where the day box isn't fully bluish colored  when selected the button's width is changed to 100% and the gradient was changed.

This happens when the calendar is stretched due to its width:

https://user-images.githubusercontent.com/24198681/228557153-f4efbc09-8878-4fec-b075-650935257b59.mov


With the fix:

https://user-images.githubusercontent.com/24198681/228557267-774bf60f-645e-4751-b316-9c924d6fc7dc.mov
